### PR TITLE
Simplify mpu_array2str and guard pagenow access

### DIFF
--- a/includes/core/frontend-functions.php
+++ b/includes/core/frontend-functions.php
@@ -148,7 +148,8 @@ function mpu_is_show_page()
     }
 
     // 檢查登入/註冊頁面
-    if (in_array($GLOBALS["pagenow"], ["wp-login.php", "wp-register.php"])) {
+    $pagenow = $GLOBALS["pagenow"] ?? "";
+    if (in_array($pagenow, ["wp-login.php", "wp-register.php"], true)) {
         return false;
     }
 

--- a/includes/core/utility-functions.php
+++ b/includes/core/utility-functions.php
@@ -29,16 +29,12 @@ if (!defined('MPU_CACHE_DEFAULT')) {
  */
 function mpu_array2str($arr = [])
 {
-    $str = "";
-    if (!empty($arr)) {
-        $n = 0;
-        $len = count($arr);
-        foreach ($arr as $value) {
-            // 使用 PHP_EOL 代替硬編碼的 \n\n 增強跨平台相容性
-            $str .= $n++ == $len - 1 ? $value : $value . PHP_EOL . PHP_EOL;
-        }
+    if (empty($arr)) {
+        return "";
     }
-    return $str;
+
+    // 使用 PHP_EOL 代替硬編碼的 \n\n 增強跨平台相容性
+    return implode(PHP_EOL . PHP_EOL, $arr);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- 精簡工具函數以提升可讀性與效能，並改善跨平台換行處理。 
- 避免在檢查登入/註冊頁時因未定義的 `$GLOBALS['pagenow']` 造成的警告或錯誤。

### Description
- 將 `mpu_array2str` 的手動迴圈替換為 `implode(PHP_EOL . PHP_EOL, $arr)` 並在空陣列時立即返回空字串以簡化實作（`includes/core/utility-functions.php`）。
- 在判斷登入/註冊頁面的檢查中使用 `$pagenow = $GLOBALS['pagenow'] ?? ''` 並以嚴格模式調用 `in_array` 以避免未定義索引與非嚴格比較問題（`includes/core/frontend-functions.php`）。

### Testing
- 未執行任何自動化測試。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969dca1c458832a87a43aeb1d5eb2e5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Simplifies `mpu_array2str` by returning early on empty arrays and using `implode(PHP_EOL . PHP_EOL, $arr)` for cross-platform line breaks
> - Hardens login/register page detection in `mpu_is_show_page()` by safely reading `$pagenow` via null coalescing and using strict `in_array`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a1288104c1c38a735497e827f2452a4d89ee278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->